### PR TITLE
Added validation of payloads against JSON schema in PatientRecord validation and upload endpoints

### DIFF
--- a/app/controllers/de/dnpm/dip/rest/api/JsonSchemata.scala
+++ b/app/controllers/de/dnpm/dip/rest/api/JsonSchemata.scala
@@ -1,0 +1,56 @@
+package de.dnpm.dip.rest.api
+
+
+import scala.jdk.CollectionConverters._
+import cats.Eval
+import cats.syntax.either._
+import play.api.libs.json.Json
+import play.api.mvc.Result
+import play.api.mvc.Results.BadRequest
+import com.networknt.schema.{
+  JsonSchemaFactory,
+  SpecVersion
+}
+import com.fasterxml.jackson.databind.ObjectMapper
+import de.dnpm.dip.rest.util.Outcome
+
+
+trait JsonSchemata[T]
+{
+
+  /**
+   * Map of JSON schemata by schema spec version
+   *
+   * Eval used as value type to allow lazily populating the Map with Eval.later(...)
+   */
+  protected val formattedSchemata: Map[String,Eval[String]]
+
+
+  /**
+   * Function taking a DataUpload[T] payload as JSON String to perform validation
+   * against the expected JSON schema.
+   * The Left(Result) case serves to indicate that the payload couldn't be processed
+   * as JSON in the first place, e.g. when malformed
+   */
+  protected lazy val schemaValidator: String => Either[Result,List[String]] = {
+
+    val objectMapper = new ObjectMapper
+
+    lazy val schema =
+      JsonSchemaFactory
+        .getInstance(SpecVersion.VersionFlag.V202012)
+        .getSchema(
+          formattedSchemata("draft-12").value
+        )
+
+    jsonString =>
+      // Ensure parsing errors from malformed JSON are reported as 400 BadRequest
+      Either.catchNonFatal(objectMapper.readTree(jsonString))
+        .bimap(
+          _ => BadRequest(Json.toJson(Outcome("Malformed body: Content is not valid JSON"))),
+          s => schema.validate(s).asScala.map(_.getMessage).toList
+        )
+
+  }
+
+}

--- a/app/controllers/de/dnpm/dip/rest/api/JsonSchemata.scala
+++ b/app/controllers/de/dnpm/dip/rest/api/JsonSchemata.scala
@@ -40,6 +40,8 @@ trait JsonSchemata[T]
       JsonSchemaFactory
         .getInstance(SpecVersion.VersionFlag.V202012)
         .getSchema(
+          // Hardcoded "draft-12" acceptable, because it is ensured to be available in MTB and RD implementations,
+          // and will hardly ever change
           formattedSchemata("draft-12").value
         )
 

--- a/app/controllers/de/dnpm/dip/rest/api/MTBController.scala
+++ b/app/controllers/de/dnpm/dip/rest/api/MTBController.scala
@@ -5,6 +5,7 @@ package de.dnpm.dip.rest.api
 import javax.inject.Inject
 import scala.concurrent.ExecutionContext
 import scala.util.Success
+import cats.Eval
 import play.api.mvc.{
   Action,
   AnyContent,
@@ -16,6 +17,9 @@ import play.api.cache.{
   Cached,
   AsyncCacheApi => Cache
 }
+import json.Schema
+import json.schema.Version._
+import com.github.andyglow.jsonschema.AsPlay._
 import de.dnpm.dip.rest.util._
 import de.dnpm.dip.util.Completer
 import de.dnpm.dip.coding.{
@@ -32,6 +36,7 @@ import de.dnpm.dip.mtb.model.{
   MTBPatientRecord,
   Completers
 }
+import de.dnpm.dip.service.DataUpload
 import de.dnpm.dip.service.query.Query
 import de.dnpm.dip.service.mvh.Report
 import de.dnpm.dip.mtb.validation.api.{
@@ -109,6 +114,22 @@ with MTBHypermedia
   override val ReadInvalidPatientRecord =
     MTBValidationPermissions.ReadInvalidPatientRecord
 
+
+  override val formattedJsonSchemata = {
+
+    import DataUpload.Schemas._
+    import de.dnpm.dip.mtb.model.json.Schemas._
+
+    Map(
+      "draft-12" -> Eval.later(Schema[DataUpload[MTBPatientRecord]].asPlay(Draft12("http://dnpm-dip/schema/mtb-submission"))),
+      "draft-09" -> Eval.later(Schema[DataUpload[MTBPatientRecord]].asPlay(Draft09("http://dnpm-dip/schema/mtb-submission"))),
+      "draft-07" -> Eval.later(Schema[DataUpload[MTBPatientRecord]].asPlay(Draft07("http://dnpm-dip/schema/mtb-submission"))),
+      "draft-04" -> Eval.later(Schema[DataUpload[MTBPatientRecord]].asPlay(Draft04()))
+    )
+    .map {
+      case (version,value) => version -> value.map(Json.prettyPrint)
+    }
+  }
 
   import CodingExtractors._
 

--- a/app/controllers/de/dnpm/dip/rest/api/MTBController.scala
+++ b/app/controllers/de/dnpm/dip/rest/api/MTBController.scala
@@ -5,7 +5,6 @@ package de.dnpm.dip.rest.api
 import javax.inject.Inject
 import scala.concurrent.ExecutionContext
 import scala.util.Success
-import cats.Eval
 import play.api.mvc.{
   Action,
   AnyContent,
@@ -17,9 +16,6 @@ import play.api.cache.{
   Cached,
   AsyncCacheApi => Cache
 }
-import json.Schema
-import json.schema.Version._
-import com.github.andyglow.jsonschema.AsPlay._
 import de.dnpm.dip.rest.util._
 import de.dnpm.dip.util.Completer
 import de.dnpm.dip.coding.{
@@ -36,7 +32,6 @@ import de.dnpm.dip.mtb.model.{
   MTBPatientRecord,
   Completers
 }
-import de.dnpm.dip.service.DataUpload
 import de.dnpm.dip.service.query.Query
 import de.dnpm.dip.service.mvh.Report
 import de.dnpm.dip.mtb.validation.api.{
@@ -57,9 +52,8 @@ import de.dnpm.dip.mtb.query.api.KaplanMeier.{
   SurvivalType,
   Grouping
 }
-import de.dnpm.dip.auth.api.{
-  UserPermissions,
-}
+import de.dnpm.dip.auth.api.UserPermissions
+
 
 
 class MTBController @Inject()(
@@ -72,6 +66,7 @@ class MTBController @Inject()(
 extends UseCaseController[MTBConfig](UseCasePrefix.MTB)
 with ValidationAuthorizations[UserPermissions]
 with QueryAuthorizations[UserPermissions]
+with MTBJsonSchemata
 with MTBHypermedia
 {
 
@@ -114,22 +109,6 @@ with MTBHypermedia
   override val ReadInvalidPatientRecord =
     MTBValidationPermissions.ReadInvalidPatientRecord
 
-
-  override val formattedJsonSchemata = {
-
-    import DataUpload.Schemas._
-    import de.dnpm.dip.mtb.model.json.Schemas._
-
-    Map(
-      "draft-12" -> Eval.later(Schema[DataUpload[MTBPatientRecord]].asPlay(Draft12("http://dnpm-dip/schema/mtb-submission"))),
-      "draft-09" -> Eval.later(Schema[DataUpload[MTBPatientRecord]].asPlay(Draft09("http://dnpm-dip/schema/mtb-submission"))),
-      "draft-07" -> Eval.later(Schema[DataUpload[MTBPatientRecord]].asPlay(Draft07("http://dnpm-dip/schema/mtb-submission"))),
-      "draft-04" -> Eval.later(Schema[DataUpload[MTBPatientRecord]].asPlay(Draft04()))
-    )
-    .map {
-      case (version,value) => version -> value.map(Json.prettyPrint)
-    }
-  }
 
   import CodingExtractors._
 

--- a/app/controllers/de/dnpm/dip/rest/api/MTBJsonSchemata.scala
+++ b/app/controllers/de/dnpm/dip/rest/api/MTBJsonSchemata.scala
@@ -1,0 +1,34 @@
+package de.dnpm.dip.rest.api
+
+
+import cats.Eval
+import play.api.libs.json.Json
+import json.Schema
+import json.schema.Version._
+import com.github.andyglow.jsonschema.AsPlay._
+import de.dnpm.dip.service.DataUpload
+import de.dnpm.dip.mtb.model.MTBPatientRecord
+import DataUpload.Schemas._
+import de.dnpm.dip.mtb.model.json.Schemas._
+
+
+trait MTBJsonSchemata extends JsonSchemata[DataUpload[MTBPatientRecord]]
+{
+
+  /**
+   * Map of JSON schemata by schema spec version
+   *
+   * Eval used as value type to allow lazily populating the Map with Eval.later(...)
+   */
+  override val formattedSchemata: Map[String,Eval[String]] = 
+    Map(
+      "draft-12" -> Eval.later(Schema[DataUpload[MTBPatientRecord]].asPlay(Draft12("http://dnpm-dip/schema/mtb-submission"))),
+      "draft-09" -> Eval.later(Schema[DataUpload[MTBPatientRecord]].asPlay(Draft09("http://dnpm-dip/schema/mtb-submission"))),
+      "draft-07" -> Eval.later(Schema[DataUpload[MTBPatientRecord]].asPlay(Draft07("http://dnpm-dip/schema/mtb-submission"))),
+      "draft-04" -> Eval.later(Schema[DataUpload[MTBPatientRecord]].asPlay(Draft04()))
+    )
+    .map {
+      case (version,value) => version -> value.map(Json.prettyPrint)
+    }
+
+}

--- a/app/controllers/de/dnpm/dip/rest/api/MTBRouter.scala
+++ b/app/controllers/de/dnpm/dip/rest/api/MTBRouter.scala
@@ -6,18 +6,13 @@ import scala.util.chaining._
 import play.api.routing.sird._
 import play.api.mvc.Results.Ok
 import play.api.libs.json.Json.toJson
-import json.Schema
-import json.schema.Version._
-import com.github.andyglow.jsonschema.AsPlay._
 import de.dnpm.dip.mtb.query.api.MTBConfig
 import de.dnpm.dip.mtb.model.MTBPatientRecord
-import de.dnpm.dip.mtb.model.json.Schemas._
 import de.dnpm.dip.mtb.gens.Generators._
 import de.ekut.tbi.generators.Gen
 import de.dnpm.dip.mtb.query.api.KaplanMeier
 import de.dnpm.dip.rest.util.Extractor
 import de.dnpm.dip.service.DataUpload
-import cats.Eval
 
 
 class MTBRouter @Inject()(
@@ -26,17 +21,6 @@ class MTBRouter @Inject()(
 extends UseCaseRouter[MTBConfig]
 with FakeDataGen[MTBPatientRecord]
 {
-
-  import DataUpload.Schemas._
-
-  override val jsonSchemas = 
-    Map(
-      "draft-12" -> Eval.later(Schema[DataUpload[MTBPatientRecord]].asPlay(Draft12("MTB-Patient-Record"))),
-      "draft-09" -> Eval.later(Schema[DataUpload[MTBPatientRecord]].asPlay(Draft09("MTB-Patient-Record"))),
-      "draft-07" -> Eval.later(Schema[DataUpload[MTBPatientRecord]].asPlay(Draft07("MTB-Patient-Record"))),
-      "draft-04" -> Eval.later(Schema[DataUpload[MTBPatientRecord]].asPlay(Draft04()))
-    )
-
 
   private val SurvivalType: Extractor[String,KaplanMeier.SurvivalType.Value] =
    KaplanMeier.SurvivalType.unapply(_)

--- a/app/controllers/de/dnpm/dip/rest/api/RDController.scala
+++ b/app/controllers/de/dnpm/dip/rest/api/RDController.scala
@@ -4,6 +4,7 @@ package de.dnpm.dip.rest.api
 
 import javax.inject.Inject
 import scala.concurrent.ExecutionContext
+import cats.Eval
 import play.api.mvc.{
   Action,
   AnyContent,
@@ -15,8 +16,12 @@ import play.api.cache.{
   Cached,
   AsyncCacheApi => Cache
 }
+import json.Schema
+import json.schema.Version._
+import com.github.andyglow.jsonschema.AsPlay._
 import de.dnpm.dip.rest.util._
 import de.dnpm.dip.util.Completer
+import de.dnpm.dip.service.DataUpload
 import de.dnpm.dip.service.query.Query
 import de.dnpm.dip.service.mvh.Report
 import de.dnpm.dip.coding.Coding 
@@ -96,6 +101,23 @@ with RDHypermedia
 
   override val ReadInvalidPatientRecord =
     RDValidationPermissions.ReadInvalidPatientRecord
+
+
+  override val formattedJsonSchemata = {
+
+    import DataUpload.Schemas._
+    import de.dnpm.dip.rd.model.json.Schemas._
+
+    Map(
+      "draft-12" -> Eval.later(Schema[DataUpload[RDPatientRecord]].asPlay(Draft12("http://dnpm-dip/schema/rd-submission"))),
+      "draft-09" -> Eval.later(Schema[DataUpload[RDPatientRecord]].asPlay(Draft09("http://dnpm-dip/schema/rd-submission"))),
+      "draft-07" -> Eval.later(Schema[DataUpload[RDPatientRecord]].asPlay(Draft07("http://dnpm-dip/schema/rd-submission"))),
+      "draft-04" -> Eval.later(Schema[DataUpload[RDPatientRecord]].asPlay(Draft04()))
+    )
+    .map {
+      case (version,value) => version -> value.map(Json.prettyPrint)
+    }
+  }
 
 
   import CodingExtractors._

--- a/app/controllers/de/dnpm/dip/rest/api/RDController.scala
+++ b/app/controllers/de/dnpm/dip/rest/api/RDController.scala
@@ -4,7 +4,7 @@ package de.dnpm.dip.rest.api
 
 import javax.inject.Inject
 import scala.concurrent.ExecutionContext
-import cats.Eval
+//import cats.Eval
 import play.api.mvc.{
   Action,
   AnyContent,
@@ -16,12 +16,12 @@ import play.api.cache.{
   Cached,
   AsyncCacheApi => Cache
 }
-import json.Schema
-import json.schema.Version._
-import com.github.andyglow.jsonschema.AsPlay._
+//import json.Schema
+//import json.schema.Version._
+//import com.github.andyglow.jsonschema.AsPlay._
 import de.dnpm.dip.rest.util._
 import de.dnpm.dip.util.Completer
-import de.dnpm.dip.service.DataUpload
+//import de.dnpm.dip.service.DataUpload
 import de.dnpm.dip.service.query.Query
 import de.dnpm.dip.service.mvh.Report
 import de.dnpm.dip.coding.Coding 
@@ -59,6 +59,7 @@ class RDController @Inject()(
 extends UseCaseController[RDConfig](UseCasePrefix.RD)
 with ValidationAuthorizations[UserPermissions]
 with QueryAuthorizations[UserPermissions]
+with RDJsonSchemata
 with RDHypermedia
 {
 
@@ -102,7 +103,7 @@ with RDHypermedia
   override val ReadInvalidPatientRecord =
     RDValidationPermissions.ReadInvalidPatientRecord
 
-
+/*
   override val formattedJsonSchemata = {
 
     import DataUpload.Schemas._
@@ -118,7 +119,7 @@ with RDHypermedia
       case (version,value) => version -> value.map(Json.prettyPrint)
     }
   }
-
+*/
 
   import CodingExtractors._
 

--- a/app/controllers/de/dnpm/dip/rest/api/RDController.scala
+++ b/app/controllers/de/dnpm/dip/rest/api/RDController.scala
@@ -4,7 +4,6 @@ package de.dnpm.dip.rest.api
 
 import javax.inject.Inject
 import scala.concurrent.ExecutionContext
-//import cats.Eval
 import play.api.mvc.{
   Action,
   AnyContent,
@@ -16,12 +15,8 @@ import play.api.cache.{
   Cached,
   AsyncCacheApi => Cache
 }
-//import json.Schema
-//import json.schema.Version._
-//import com.github.andyglow.jsonschema.AsPlay._
 import de.dnpm.dip.rest.util._
 import de.dnpm.dip.util.Completer
-//import de.dnpm.dip.service.DataUpload
 import de.dnpm.dip.service.query.Query
 import de.dnpm.dip.service.mvh.Report
 import de.dnpm.dip.coding.Coding 
@@ -103,23 +98,6 @@ with RDHypermedia
   override val ReadInvalidPatientRecord =
     RDValidationPermissions.ReadInvalidPatientRecord
 
-/*
-  override val formattedJsonSchemata = {
-
-    import DataUpload.Schemas._
-    import de.dnpm.dip.rd.model.json.Schemas._
-
-    Map(
-      "draft-12" -> Eval.later(Schema[DataUpload[RDPatientRecord]].asPlay(Draft12("http://dnpm-dip/schema/rd-submission"))),
-      "draft-09" -> Eval.later(Schema[DataUpload[RDPatientRecord]].asPlay(Draft09("http://dnpm-dip/schema/rd-submission"))),
-      "draft-07" -> Eval.later(Schema[DataUpload[RDPatientRecord]].asPlay(Draft07("http://dnpm-dip/schema/rd-submission"))),
-      "draft-04" -> Eval.later(Schema[DataUpload[RDPatientRecord]].asPlay(Draft04()))
-    )
-    .map {
-      case (version,value) => version -> value.map(Json.prettyPrint)
-    }
-  }
-*/
 
   import CodingExtractors._
 

--- a/app/controllers/de/dnpm/dip/rest/api/RDJsonSchemata.scala
+++ b/app/controllers/de/dnpm/dip/rest/api/RDJsonSchemata.scala
@@ -1,0 +1,34 @@
+package de.dnpm.dip.rest.api
+
+
+import cats.Eval
+import play.api.libs.json.Json
+import json.Schema
+import json.schema.Version._
+import com.github.andyglow.jsonschema.AsPlay._
+import de.dnpm.dip.service.DataUpload
+import de.dnpm.dip.rd.model.RDPatientRecord
+import DataUpload.Schemas._
+import de.dnpm.dip.rd.model.json.Schemas._
+
+
+trait RDJsonSchemata extends JsonSchemata[DataUpload[RDPatientRecord]]
+{
+
+  /**
+   * Map of JSON schemata by schema spec version
+   *
+   * Eval used as value type to allow lazily populating the Map with Eval.later(...)
+   */
+  override val formattedSchemata: Map[String,Eval[String]] = 
+    Map(
+      "draft-12" -> Eval.later(Schema[DataUpload[RDPatientRecord]].asPlay(Draft12("http://dnpm-dip/schema/rd-submission"))),
+      "draft-09" -> Eval.later(Schema[DataUpload[RDPatientRecord]].asPlay(Draft09("http://dnpm-dip/schema/rd-submission"))),
+      "draft-07" -> Eval.later(Schema[DataUpload[RDPatientRecord]].asPlay(Draft07("http://dnpm-dip/schema/rd-submission"))),
+      "draft-04" -> Eval.later(Schema[DataUpload[RDPatientRecord]].asPlay(Draft04()))
+    )
+    .map {
+      case (version,value) => version -> value.map(Json.prettyPrint)
+    }
+
+}

--- a/app/controllers/de/dnpm/dip/rest/api/RDRouter.scala
+++ b/app/controllers/de/dnpm/dip/rest/api/RDRouter.scala
@@ -6,16 +6,11 @@ import scala.util.chaining._
 import play.api.routing.sird._
 import play.api.mvc.Results.Ok
 import play.api.libs.json.Json.toJson
-import json.Schema
-import json.schema.Version._
-import com.github.andyglow.jsonschema.AsPlay._
 import de.dnpm.dip.rd.query.api.RDConfig
 import de.dnpm.dip.rd.model.RDPatientRecord
-import de.dnpm.dip.rd.model.json.Schemas._
 import de.dnpm.dip.rd.gens.Generators._
 import de.ekut.tbi.generators.Gen
 import de.dnpm.dip.service.DataUpload
-import cats.Eval
 
 
 class RDRouter @Inject()(
@@ -24,16 +19,6 @@ class RDRouter @Inject()(
 extends UseCaseRouter[RDConfig]
 with FakeDataGen[RDPatientRecord]
 {
-
-  import DataUpload.Schemas._
-
-  override val jsonSchemas =
-    Map(
-      "draft-12" -> Eval.later(Schema[DataUpload[RDPatientRecord]].asPlay(Draft12("RD-Patient-Record"))),
-      "draft-09" -> Eval.later(Schema[DataUpload[RDPatientRecord]].asPlay(Draft09("RD-Patient-Record"))),
-      "draft-07" -> Eval.later(Schema[DataUpload[RDPatientRecord]].asPlay(Draft07("RD-Patient-Record"))),
-      "draft-04" -> Eval.later(Schema[DataUpload[RDPatientRecord]].asPlay(Draft04()))
-    )
 
   override val additionalRoutes = {
 

--- a/app/controllers/de/dnpm/dip/rest/api/UseCaseController.scala
+++ b/app/controllers/de/dnpm/dip/rest/api/UseCaseController.scala
@@ -20,7 +20,8 @@ import play.api.mvc.{
   Action,
   AnyContent,
   BaseController,
-  RequestHeader
+  RequestHeader,
+  Result
 }
 import play.api.libs.json.{
   Json,
@@ -109,9 +110,11 @@ import de.dnpm.dip.rest.util._
 import de.dnpm.dip.rest.util.sapphyre.Hyper
 import com.networknt.schema.{
   JsonSchemaFactory,
-//  JSonSchema,
   SpecVersion
 }
+import com.fasterxml.jackson.databind.ObjectMapper
+import scala.jdk.CollectionConverters._
+
 
 final case class QueryPatch[Criteria]
 (
@@ -296,17 +299,30 @@ with AuthorizationOps[UserPermissions]
   // Data Operations
   // --------------------------------------------------------------------------  
 
-//  protected val patientRecordParser =
-//    JsonBody[DataUpload[PatientRecord]]
+  protected val dataUploadSchemaValidator: String => Either[Result,List[String]] = {
 
-  protected lazy val patientRecordParser =
-    SchemaValidatedJsonBody[DataUpload[PatientRecord]](
+    val objectMapper = new ObjectMapper
+
+    lazy val schema =
       JsonSchemaFactory
         .getInstance(SpecVersion.VersionFlag.V202012)
         .getSchema(
           formattedJsonSchemata("draft-12").value
         )
-    )
+
+    jsonString => 
+      // Ensure parsing errors from malformed JSON are reported as 400 BadRequest
+      Either.catchNonFatal(objectMapper.readTree(jsonString))
+        .bimap(
+          t => BadRequest(Json.toJson(Outcome(t.getMessage))),
+          s => schema.validate(s).asScala.map(_.getMessage).toList
+        )
+
+  }
+
+  protected val patientRecordParser =
+    SchemaValidatedJsonBody[DataUpload[PatientRecord]](dataUploadSchemaValidator)
+
 
   def validate =
     Action.async(patientRecordParser){ 

--- a/app/controllers/de/dnpm/dip/rest/api/UseCaseController.scala
+++ b/app/controllers/de/dnpm/dip/rest/api/UseCaseController.scala
@@ -32,10 +32,7 @@ import play.api.cache.{
   Cached,
   AsyncCacheApi => Cache
 }
-import cats.{
-  Eval,
-  Monad
-}
+import cats.Monad
 import cats.data.NonEmptyList
 import cats.syntax.either._
 import de.dnpm.dip.util.Completer
@@ -44,9 +41,7 @@ import de.dnpm.dip.service.{
   Orchestrator,
   UsageScope
 }
-import de.dnpm.dip.connector.{
-  HttpConnector
-}
+import de.dnpm.dip.connector.HttpConnector
 import HttpConnector.QueryParameters
 import HttpConnector.QueryParameters._
 import de.dnpm.dip.connector.HttpMethod._
@@ -156,14 +151,6 @@ with AuthorizationOps[UserPermissions]
   protected val cached: Cached
   protected val cachingDuration: Duration = 15 minutes
   protected val CACHE_CONTROL_SETTINGS = "no-store"
-
-
-  /**
-   * Map of JSON schemata by schema spec version
-   *
-   * Eval used as value type to allow lazily populating the Map with Eval.later(...)
-   */
-  protected val formattedSchemata: Map[String,Eval[String]]
 
 
   protected implicit val completer: Completer[PatientRecord]

--- a/app/controllers/de/dnpm/dip/rest/api/UseCaseController.scala
+++ b/app/controllers/de/dnpm/dip/rest/api/UseCaseController.scala
@@ -32,7 +32,10 @@ import play.api.cache.{
   Cached,
   AsyncCacheApi => Cache
 }
-import cats.Monad
+import cats.{
+  Eval,
+  Monad
+}
 import cats.data.NonEmptyList
 import cats.syntax.either._
 import de.dnpm.dip.util.Completer
@@ -104,7 +107,11 @@ import de.dnpm.dip.auth.api.{
 }
 import de.dnpm.dip.rest.util._
 import de.dnpm.dip.rest.util.sapphyre.Hyper
-
+import com.networknt.schema.{
+  JsonSchemaFactory,
+//  JSonSchema,
+  SpecVersion
+}
 
 final case class QueryPatch[Criteria]
 (
@@ -153,6 +160,14 @@ with AuthorizationOps[UserPermissions]
   protected val cached: Cached
   protected val cachingDuration: Duration = 15 minutes
   protected val CACHE_CONTROL_SETTINGS = "no-store"
+
+
+  /**
+   * Map of JSON schemata by schema spec version
+   *
+   * Eval used as value type to allow lazily populating the Map with Eval.later(...)
+   */
+  protected val formattedJsonSchemata: Map[String,Eval[String]]
 
 
   protected implicit val completer: Completer[PatientRecord]
@@ -263,14 +278,35 @@ with AuthorizationOps[UserPermissions]
         .map(Ok(_))
     }
 
+  def jsonSchema(version: Option[String]) =
+    Action {
+      formattedJsonSchemata.get(version.getOrElse("draft-12").toLowerCase) match {
+        case Some(sch) =>
+          Ok(sch.value).as("application/json")
+
+        case None =>
+          NotFound(
+            Json.toJson(Outcome(s"Invalid JSON schema version, expected one of {${formattedJsonSchemata.keys.mkString(",")}}"))
+          )
+      }
+    }
+
 
   // --------------------------------------------------------------------------  
   // Data Operations
   // --------------------------------------------------------------------------  
 
-  protected val patientRecordParser =
-    JsonBody[DataUpload[PatientRecord]]
+//  protected val patientRecordParser =
+//    JsonBody[DataUpload[PatientRecord]]
 
+  protected lazy val patientRecordParser =
+    SchemaValidatedJsonBody[DataUpload[PatientRecord]](
+      JsonSchemaFactory
+        .getInstance(SpecVersion.VersionFlag.V202012)
+        .getSchema(
+          formattedJsonSchemata("draft-12").value
+        )
+    )
 
   def validate =
     Action.async(patientRecordParser){ 

--- a/app/controllers/de/dnpm/dip/rest/api/UseCaseController.scala
+++ b/app/controllers/de/dnpm/dip/rest/api/UseCaseController.scala
@@ -21,7 +21,6 @@ import play.api.mvc.{
   AnyContent,
   BaseController,
   RequestHeader,
-  Result
 }
 import play.api.libs.json.{
   Json,
@@ -108,13 +107,6 @@ import de.dnpm.dip.auth.api.{
 }
 import de.dnpm.dip.rest.util._
 import de.dnpm.dip.rest.util.sapphyre.Hyper
-import com.networknt.schema.{
-  JsonSchemaFactory,
-  SpecVersion
-}
-import com.fasterxml.jackson.databind.ObjectMapper
-import scala.jdk.CollectionConverters._
-
 
 final case class QueryPatch[Criteria]
 (
@@ -147,6 +139,7 @@ with AuthorizationOps[UserPermissions]
   this: 
     QueryAuthorizations[UserPermissions]
     with ValidationAuthorizations[UserPermissions]
+    with JsonSchemata[DataUpload[UseCase#PatientRecord]]
     with UseCaseHypermedia[UseCase] =>
 
 
@@ -170,7 +163,7 @@ with AuthorizationOps[UserPermissions]
    *
    * Eval used as value type to allow lazily populating the Map with Eval.later(...)
    */
-  protected val formattedJsonSchemata: Map[String,Eval[String]]
+  protected val formattedSchemata: Map[String,Eval[String]]
 
 
   protected implicit val completer: Completer[PatientRecord]
@@ -283,13 +276,13 @@ with AuthorizationOps[UserPermissions]
 
   def jsonSchema(version: Option[String]) =
     Action {
-      formattedJsonSchemata.get(version.getOrElse("draft-12").toLowerCase) match {
+      formattedSchemata.get(version.getOrElse("draft-12").toLowerCase) match {
         case Some(sch) =>
           Ok(sch.value).as("application/json")
 
         case None =>
           NotFound(
-            Json.toJson(Outcome(s"Invalid JSON schema version, expected one of {${formattedJsonSchemata.keys.mkString(",")}}"))
+            Json.toJson(Outcome(s"Invalid JSON schema version, expected one of {${formattedSchemata.keys.mkString(",")}}"))
           )
       }
     }
@@ -299,29 +292,8 @@ with AuthorizationOps[UserPermissions]
   // Data Operations
   // --------------------------------------------------------------------------  
 
-  protected val dataUploadSchemaValidator: String => Either[Result,List[String]] = {
-
-    val objectMapper = new ObjectMapper
-
-    lazy val schema =
-      JsonSchemaFactory
-        .getInstance(SpecVersion.VersionFlag.V202012)
-        .getSchema(
-          formattedJsonSchemata("draft-12").value
-        )
-
-    jsonString => 
-      // Ensure parsing errors from malformed JSON are reported as 400 BadRequest
-      Either.catchNonFatal(objectMapper.readTree(jsonString))
-        .bimap(
-          t => BadRequest(Json.toJson(Outcome(t.getMessage))),
-          s => schema.validate(s).asScala.map(_.getMessage).toList
-        )
-
-  }
-
   protected val patientRecordParser =
-    SchemaValidatedJsonBody[DataUpload[PatientRecord]](dataUploadSchemaValidator)
+    SchemaValidatedJsonBody[DataUpload[PatientRecord]](schemaValidator)
 
 
   def validate =
@@ -387,38 +359,6 @@ with AuthorizationOps[UserPermissions]
                 .leftMap(Outcome(_))
                 .fold(Json.toJson(_),Json.toJson(_))
             )
-            
-/*            
-            val result =
-              errs.foldLeft(Option.empty[(Int,Either[NonEmptyList[String],ValidationReport])]){
-                (acc,err) => err match {
-                  case Left(FatalIssuesDetected(report))         => Some(BAD_REQUEST -> report.asRight)
-              
-                  case Left(UnacceptableIssuesDetected(report))  => Some(UNPROCESSABLE_ENTITY -> report.asRight)
-              
-                  case Left(ValidationService.GenericError(msg)) => Some(INTERNAL_SERVER_ERROR -> NonEmptyList.of(msg).asLeft)
-              
-                  case Right(Left(MVHService.InvalidTAN(msg)))   => Some(BAD_REQUEST -> NonEmptyList.of(msg).asLeft)
-              
-                  case Right(Left(MVHService.GenericError(msg))) =>
-                    acc.collect {
-                      case (sc,Left(msgs)) if sc == INTERNAL_SERVER_ERROR => sc -> (msg :: msgs).asLeft
-                    }
-                    .orElse(Some(INTERNAL_SERVER_ERROR -> NonEmptyList.of(msg).asLeft))
-              
-                  case Right(Right(QueryService.GenericError(msg))) =>
-                    acc.collect {
-                      case (sc,Left(msgs)) if sc == INTERNAL_SERVER_ERROR => sc -> (msg :: msgs).asLeft
-                    }
-                    .orElse(Some(INTERNAL_SERVER_ERROR -> NonEmptyList.of(msg).asLeft))
-                }
-              }
-
-            result match {
-              case Some(sc -> result) => Status(sc)(result.leftMap(Outcome(_)).fold(Json.toJson(_),Json.toJson(_)))
-              case None => Ok
-            }
-*/            
         }
     }
 

--- a/app/controllers/de/dnpm/dip/rest/api/UseCaseRouter.scala
+++ b/app/controllers/de/dnpm/dip/rest/api/UseCaseRouter.scala
@@ -78,12 +78,6 @@ abstract class UseCaseRouter[UseCase <: UseCaseConfig] extends SimpleRouter
 
   def useCasePrefix = s"/${controller.useCasePrefix}"
   
-/*
-  protected val APPLICATION_JSON = "application/json"
-
-  protected val jsonSchemas: Map[String,Eval[JsObject]]
-*/
-
   final val baseRoutes: Routes = {
 
     case GET(p"/sites") => controller.sites
@@ -95,19 +89,6 @@ abstract class UseCaseRouter[UseCase <: UseCaseConfig] extends SimpleRouter
 
     case GET(p"/etl/patient-record/schema"?q_o"version=$version") =>
       controller.jsonSchema(version)
-/*      
-      controller.Action { req =>
-        jsonSchemas.get(version.getOrElse("draft-12").toLowerCase) match {
-          case Some(sch) =>
-            Ok(Json.prettyPrint(sch.value)).as(APPLICATION_JSON)
-
-          case None =>
-            NotFound(
-              Json.toJson(Outcome(s"Invalid JSON schema version, expected one of {${jsonSchemas.keys.mkString(",")}}"))
-            )
-        }
-      }
-*/
 
     case POST(p"/etl/patient-record:validate") => controller.validate
 

--- a/app/controllers/de/dnpm/dip/rest/api/UseCaseRouter.scala
+++ b/app/controllers/de/dnpm/dip/rest/api/UseCaseRouter.scala
@@ -9,14 +9,6 @@ import java.time.{
 import play.api.routing.Router.Routes
 import play.api.routing.SimpleRouter
 import play.api.routing.sird._
-import play.api.mvc.Results.{
-  NotFound,
-  Ok
-}
-import play.api.libs.json.{
-  Json,
-  JsObject
-}
 import de.dnpm.dip.coding.Coding
 import de.dnpm.dip.model.{
   Id,
@@ -39,11 +31,7 @@ import de.dnpm.dip.service.query.{
   PreparedQuery,
   UseCaseConfig
 }
-import de.dnpm.dip.rest.util.{
-  Extractor,
-  Outcome
-}
-import cats.Eval
+import de.dnpm.dip.rest.util.Extractor
 
 
 abstract class UseCaseRouter[UseCase <: UseCaseConfig] extends SimpleRouter
@@ -90,11 +78,11 @@ abstract class UseCaseRouter[UseCase <: UseCaseConfig] extends SimpleRouter
 
   def useCasePrefix = s"/${controller.useCasePrefix}"
   
-
+/*
   protected val APPLICATION_JSON = "application/json"
 
   protected val jsonSchemas: Map[String,Eval[JsObject]]
-
+*/
 
   final val baseRoutes: Routes = {
 
@@ -106,6 +94,8 @@ abstract class UseCaseRouter[UseCase <: UseCaseConfig] extends SimpleRouter
     // ------------------------------------------------------------------------
 
     case GET(p"/etl/patient-record/schema"?q_o"version=$version") =>
+      controller.jsonSchema(version)
+/*      
       controller.Action { req =>
         jsonSchemas.get(version.getOrElse("draft-12").toLowerCase) match {
           case Some(sch) =>
@@ -117,6 +107,7 @@ abstract class UseCaseRouter[UseCase <: UseCaseConfig] extends SimpleRouter
             )
         }
       }
+*/
 
     case POST(p"/etl/patient-record:validate") => controller.validate
 

--- a/app/util/de/dnpm/dip/rest/util/JsonOps.scala
+++ b/app/util/de/dnpm/dip/rest/util/JsonOps.scala
@@ -26,9 +26,6 @@ import play.api.mvc.{
   RequestHeader,
   Result
 }
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.networknt.schema.JsonSchema
-import scala.jdk.CollectionConverters._
 
 
 trait JsonOps
@@ -52,10 +49,8 @@ trait JsonOps
        )
 
 
-  private val objectMapper = new ObjectMapper
-
   def SchemaValidatedJsonBody[T: Reads](
-    schema: JsonSchema
+    schemaValidator: String => Either[Result,List[String]]
   )(
     implicit ec: ExecutionContext
   ): BodyParser[T] =
@@ -70,28 +65,20 @@ trait JsonOps
       )
       .validate {
         jsonString =>
-
-          // Ensure parsing errors from malformed JSON are reported as 400 BadRequest
-          Either.catchNonFatal(objectMapper.readTree(jsonString))
-            .leftMap(t => BadRequest(Json.toJson(Outcome(t.getMessage))))
-            .flatMap {
-              json =>
-
-                val validationErrors = schema.validate(json).asScala.toList
+          schemaValidator(jsonString).flatMap {
+            errs => NonEmptyList.fromList(errs) match {
                 
-                NonEmptyList.fromList(validationErrors) match {
-                
-                  case Some(errors) =>
-                    BadRequest(Json.toJson(Outcome(errors.map(_.getMessage)))).asLeft
-                
-                  case None  =>
-                    Json.parse(jsonString).validate[T]
-                      .asEither
-                      .leftMap(errors => BadRequest(Json.toJson(Outcome(errors))))
-                }
+              case Some(errors) =>
+                BadRequest(Json.toJson(Outcome(errors))).asLeft
+              
+              case None  =>
+                Json.parse(jsonString).validate[T]
+                  .asEither
+                  .leftMap(errors => BadRequest(Json.toJson(Outcome(errors))))
             }
+          }
       }
-  
+
 
   def JsonBodyOpt[T: Reads](
     implicit ec: ExecutionContext

--- a/app/util/de/dnpm/dip/rest/util/JsonOps.scala
+++ b/app/util/de/dnpm/dip/rest/util/JsonOps.scala
@@ -5,7 +5,6 @@ import scala.concurrent.{
   Future,
   ExecutionContext
 }
-import scala.util.Either
 import cats.data.{
   Ior,
   IorNel,
@@ -27,6 +26,9 @@ import play.api.mvc.{
   RequestHeader,
   Result
 }
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.networknt.schema.JsonSchema
+import scala.jdk.CollectionConverters._
 
 
 trait JsonOps
@@ -46,8 +48,38 @@ trait JsonOps
          .leftMap(
            errs => BadRequest(Json.toJson(Outcome(errs))),
          )
+    
        )
 
+
+  private val objectMapper = new ObjectMapper
+
+  def SchemaValidatedJsonBody[T: Reads](
+    schema: JsonSchema
+  )(
+    implicit ec: ExecutionContext
+  ): BodyParser[T] =
+    // Tolerant text used deliberately here, because the expected payload type is JSON,
+    // but the request shopuld be accepted irrespective of the specified Content-type header
+    parse.byteString
+      .map(_.decodeString("UTF-8"))
+      .validate {
+        json =>
+
+          val validationErrors = schema.validate(objectMapper.readTree(json)).asScala.toList
+
+          NonEmptyList.fromList(validationErrors) match {
+
+            case Some(errors) =>
+              BadRequest(Json.toJson(Outcome(errors.map(_.getMessage)))).asLeft
+
+            case None  =>
+              Json.parse(json).validate[T]
+                .asEither
+                .leftMap(errors => BadRequest(Json.toJson(Outcome(errors))))
+          }
+      }
+  
 
   def JsonBodyOpt[T: Reads](
     implicit ec: ExecutionContext

--- a/app/util/de/dnpm/dip/rest/util/JsonOps.scala
+++ b/app/util/de/dnpm/dip/rest/util/JsonOps.scala
@@ -59,25 +59,37 @@ trait JsonOps
   )(
     implicit ec: ExecutionContext
   ): BodyParser[T] =
-    // Tolerant text used deliberately here, because the expected payload type is JSON,
-    // but the request shopuld be accepted irrespective of the specified Content-type header
+    // ByteString parser used deliberately here, because the expected payload type is JSON,
+    // but the request should be accepted irrespective of the specified Content-type and charset
     parse.byteString
-      .map(_.decodeString("UTF-8"))
+      .validate(
+        bs =>
+          // JSON string should be UTF-8 encoded, so ensure this
+          Either.catchNonFatal(bs.decodeString("UTF-8"))
+            .leftMap(t => BadRequest(Json.toJson(Outcome(t.getMessage))))
+      )
       .validate {
-        json =>
+        jsonString =>
 
-          val validationErrors = schema.validate(objectMapper.readTree(json)).asScala.toList
+          // Ensure parsing errors from malformed JSON are reported as 400 BadRequest
+          Either.catchNonFatal(objectMapper.readTree(jsonString))
+            .leftMap(t => BadRequest(Json.toJson(Outcome(t.getMessage))))
+            .flatMap {
+              json =>
 
-          NonEmptyList.fromList(validationErrors) match {
-
-            case Some(errors) =>
-              BadRequest(Json.toJson(Outcome(errors.map(_.getMessage)))).asLeft
-
-            case None  =>
-              Json.parse(json).validate[T]
-                .asEither
-                .leftMap(errors => BadRequest(Json.toJson(Outcome(errors))))
-          }
+                val validationErrors = schema.validate(json).asScala.toList
+                
+                NonEmptyList.fromList(validationErrors) match {
+                
+                  case Some(errors) =>
+                    BadRequest(Json.toJson(Outcome(errors.map(_.getMessage)))).asLeft
+                
+                  case None  =>
+                    Json.parse(jsonString).validate[T]
+                      .asEither
+                      .leftMap(errors => BadRequest(Json.toJson(Outcome(errors))))
+                }
+            }
       }
   
 

--- a/app/util/de/dnpm/dip/rest/util/JsonOps.scala
+++ b/app/util/de/dnpm/dip/rest/util/JsonOps.scala
@@ -19,36 +19,53 @@ import play.api.libs.json.{
   Writes
 }
 import play.api.mvc.{
-  BaseController,
+  BaseControllerHelpers,
   ActionBuilder,
   BodyParser,
+  PlayBodyParsers,
   Request,
   RequestHeader,
   Result
 }
+import play.api.mvc.Results.BadRequest
 
 
-trait JsonOps
+trait CustomBodyParsers
 {
 
-  self: BaseController =>
-
+  def parse: PlayBodyParsers
 
   def JsonBody[T: Reads](
     implicit ec: ExecutionContext
   ): BodyParser[T] =
-    parse
-      .tolerantJson
+    parse.tolerantJson
       .validate(
         _.validate[T]
          .asEither
          .leftMap(
            errs => BadRequest(Json.toJson(Outcome(errs))),
          )
-    
        )
 
+  def JsonBodyOpt[T: Reads](
+    implicit ec: ExecutionContext
+  ): BodyParser[Option[T]] =
+    parse.tolerantJson
+      .validate(
+        _.validateOpt[T]
+         .asEither
+         .leftMap(
+           errs => BadRequest(Json.toJson(Outcome(errs))),
+         )
+       )
 
+  /**
+   * Utility method to build a BodyParser[T] that performs validation based on the injected function
+   * before proceeding with JSON-to-DTO deserialization.
+   *
+   * @param schemaValidator: Function to validate a JSON string:
+   * Returns a Result in case of failure to even process the JSON (malformed, etc) else a potentially empty list of validation errors
+   */
   def SchemaValidatedJsonBody[T: Reads](
     schemaValidator: String => Either[Result,List[String]]
   )(
@@ -61,7 +78,7 @@ trait JsonOps
         bs =>
           // JSON string should be UTF-8 encoded, so ensure this
           Either.catchNonFatal(bs.decodeString("UTF-8"))
-            .leftMap(t => BadRequest(Json.toJson(Outcome(t.getMessage))))
+            .leftMap(t => BadRequest(Json.toJson(Outcome("Malformed body: JSON content is expected to be decodable as UTF-8"))))
       )
       .validate {
         jsonString =>
@@ -79,19 +96,13 @@ trait JsonOps
           }
       }
 
+}
 
-  def JsonBodyOpt[T: Reads](
-    implicit ec: ExecutionContext
-  ): BodyParser[Option[T]] =
-    parse
-      .tolerantJson
-      .validate(
-        _.validateOpt[T]
-         .asEither
-         .leftMap(
-           errs => BadRequest(Json.toJson(Outcome(errs))),
-         )
-       )
+
+trait JsonOps extends CustomBodyParsers
+{
+
+  self: BaseControllerHelpers =>
 
 
   def JsonAction[T: Reads](
@@ -118,11 +129,9 @@ trait JsonOps
   ): ActionBuilder[Request,Option[T]] =
     new ActionBuilder[Request,Option[T]]{
 
-      override val executionContext =
-        ec
+      override val executionContext = ec
 
-      override val parser =
-        JsonBodyOpt[T]
+      override val parser = JsonBodyOpt[T]
 
       override def invokeBlock[A](
         request: Request[A],

--- a/build.sbt
+++ b/build.sbt
@@ -21,11 +21,23 @@ lazy val root = (project in file("."))
   )
 
 
+val jacksonVersion = "2.18.3" 
+
+
 libraryDependencies ++= Seq(
   caffeine,
   guice,
   "org.scalatestplus.play" %% "scalatestplus-play"          % "7.0.2" % Test,  //TODO: version!
   "com.lihaoyi"            %% "fastparse"                   % "3.1.1",
+
+  // Pinned jacksonVersion because otherwise there's a version conflict
+  // between  the one depended on by Play itself and com.networknt.json-schema-validator
+  "com.fasterxml.jackson.core"   % "jackson-core"          % jacksonVersion,
+  "com.fasterxml.jackson.core"   % "jackson-databind"      % jacksonVersion,
+  "com.fasterxml.jackson.core"   % "jackson-annotations"   % jacksonVersion,
+  "com.fasterxml.jackson.module" %% "jackson-module-scala" % jacksonVersion,
+
+  "com.networknt"          %  "json-schema-validator"       % "1.5.9",
   "de.ekut.tbi"            %% "generators"                  % "1.0.0",
   "de.dnpm.dip"            %% "admin-service-api"           % "1.1.2",
   "de.dnpm.dip"            %% "admin-service-impl"          % "1.1.2",

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ import scala.util.Properties.envOrElse
 name := "dnpm-dip-api-gateway"
 ThisBuild / organization := "de.dnpm.dip"
 ThisBuild / scalaVersion := "2.13.18"
-ThisBuild / version      := envOrElse("VERSION","1.3.0-SNAPSHOT")
+ThisBuild / version      := envOrElse("VERSION","1.4.0-SNAPSHOT")
 
 val ownerRepo  = envOrElse("REPOSITORY","dnpm-dip/api-gateway").split("/")
 ThisBuild / githubOwner      := ownerRepo(0)
@@ -21,7 +21,7 @@ lazy val root = (project in file("."))
   )
 
 
-val jacksonVersion = "2.18.3" 
+val jacksonVersion = "2.18.8" 
 
 
 libraryDependencies ++= Seq(
@@ -31,7 +31,9 @@ libraryDependencies ++= Seq(
   "com.lihaoyi"            %% "fastparse"                   % "3.1.1",
 
   // Pinned jacksonVersion because otherwise there's a version conflict
-  // between  the one depended on by Play itself and com.networknt.json-schema-validator
+  // between the one depended on by Play itself and com.networknt.json-schema-validator
+  // Also resolves vulnerability warnings due to transitive dependency
+  // on outdated jackson modules via scala-jsonschema-play-json -> play-json 2.9.2)
   "com.fasterxml.jackson.core"   % "jackson-core"          % jacksonVersion,
   "com.fasterxml.jackson.core"   % "jackson-databind"      % jacksonVersion,
   "com.fasterxml.jackson.core"   % "jackson-annotations"   % jacksonVersion,

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.11.3
+sbt.version=1.12.12

--- a/test/scala/de/dnpm/dip/rest/api/SchemaValidationTests.scala
+++ b/test/scala/de/dnpm/dip/rest/api/SchemaValidationTests.scala
@@ -1,0 +1,60 @@
+package de.dnpm.dip.rest.api
+
+
+import scala.util.Random
+import scala.util.chaining._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.must.Matchers._
+import org.scalatest.EitherValues._
+import de.ekut.tbi.generators.Gen
+import de.dnpm.dip.mtb.model.MTBPatientRecord
+import de.dnpm.dip.mtb.gens.Generators._
+import play.api.libs.json.Json
+
+
+
+class SchemaValidationTests extends AnyFlatSpec with MTBJsonSchemata
+{
+
+  implicit val rnd: Random = new Random(42)
+
+
+  "SchemaValidator" must "have succeeded on correct JSON input" in { 
+
+    val json =
+      Gen.of[MTBPatientRecord].next
+        .pipe(Json.toJson(_))
+        .pipe(Json.stringify)
+
+    schemaValidator(json).value must be (empty) 
+
+  }
+
+
+  it must "have failed on JSON input missing required fields" in { 
+
+    val json =
+      Gen.of[MTBPatientRecord].next
+        .pipe(Json.toJsObject(_))
+        .pipe(js => js - "patient")
+        .pipe(Json.stringify)
+
+    schemaValidator(json).value must not be (empty) 
+
+  }
+
+  it must "have failed on JSON input with unexpected additional fields" in { 
+
+    val json =
+      Gen.of[MTBPatientRecord].next
+        .pipe(Json.toJsObject(_))
+        .pipe(js =>
+          js ++ Json.obj("additionalString" -> "foo")
+        )
+        .pipe(Json.stringify)
+
+    schemaValidator(json).value must not be (empty) 
+
+  }
+
+}


### PR DESCRIPTION
refactor: Moved provision of JSON schemata from UseCaseRouter to UseC…aseController
fix: Added validation of payloads against JSON schema in PatientRecord validation and upload endpoints
fix: bump sbt version
fix: Pinned Jackson version to avoid runtime version conflicts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added JSON schema validation for patient record submissions, returning structured validation errors on failures.
  * Extended schema support so the schema endpoint can serve different drafts (draft-12, draft-09, draft-07, draft-04) and returns a helpful “not found” response when a version is missing.
* **Refactor**
  * Centralized JSON-schema generation/validation into shared traits and updated controllers/routers to use the unified schema logic.
  * Simplified schema endpoint handling by delegating draft selection to the controller.
* **Chores**
  * Updated the sbt version and pinned/additions for Jackson to improve consistent JSON handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->